### PR TITLE
feat: use the new decentralized service

### DIFF
--- a/Websocket/inc/subgraph.js
+++ b/Websocket/inc/subgraph.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const thegraphAPI =
-  'https://api.thegraph.com/subgraphs/name/getprotocol/get-protocol-subgraph';
+  'https://gateway.thegraph.com/api/5cb3bc7942a919148db4e6a356a02b43/subgraphs/id/5S9b6URgphe9h19c5rQwAWd9aed1i1m1mHiqPKM1Fvvq';
 
 module.exports = {
   subgraphData: async () => {


### PR DESCRIPTION
Alters thegraphAPI variable to store the production URL for the get-protocol-polygon subgraph rather than the previous hosted service one. The hosted service is in the process of being decommissioned and it is now recommended to use the decentralized network.

For additional security the API key used is currently only authorised to make queries on the `get-protocol-polygon` subgraph.

ref:
- [Sunsetting Announcement](https://thegraph.com/blog/sunsetting-hosted-service/)
- [Network Transition FAQ](https://thegraph.com/docs/en/network-transition-faq/)